### PR TITLE
[Feat] CodeBlockHeader 에서 title , language 를 표현하도록 수정 

### DIFF
--- a/app/src/features/snippet/lib/useCopySnippetImage.ts
+++ b/app/src/features/snippet/lib/useCopySnippetImage.ts
@@ -14,11 +14,20 @@ export const useCopySnippetImage = () => {
 
     const $codeBlock = document.querySelector("#codeBlock") as HTMLDivElement;
 
+    const $codeBlockTitle = document.querySelector(
+      "#codeBlockTitle"
+    ) as HTMLInputElement;
+
     /* 스크롤바 없애기 전 저장 */
     const originalWidth = $codeBlock.style.width;
     const originalOverflowX = $codeBlock.style.overflowX;
 
     try {
+      /* 타이틀이 존재하지 않는다면 placeHolder가 나타나지 않도록 visibility 조절 */
+      if ($codeBlockTitle.value.length < 1) {
+        $codeBlockTitle.style.visibility = "hidden";
+      }
+
       $codeBlock.style.width = "fit-content";
       $codeBlock.style.overflow = "visible";
 
@@ -42,6 +51,10 @@ export const useCopySnippetImage = () => {
     } finally {
       $codeBlock.style.width = originalWidth;
       $codeBlock.style.overflowX = originalOverflowX;
+
+      if ($codeBlockTitle.value.length < 1) {
+        $codeBlockTitle.style.visibility = "visible";
+      }
 
       statusTimerRef.current = setTimeout(() => {
         setStatus("idle");

--- a/app/src/features/snippet/lib/useSnippetContent.ts
+++ b/app/src/features/snippet/lib/useSnippetContent.ts
@@ -29,6 +29,7 @@ export const useSnippetContent = () => {
       htmlContent,
       Number(snippetSetting.showLineNumbers)
     ),
+    language: snippetSetting.language,
   };
 };
 

--- a/app/src/features/snippet/ui/CodeBlock.tsx
+++ b/app/src/features/snippet/ui/CodeBlock.tsx
@@ -3,7 +3,6 @@
 import styles from "./styles.module.css";
 import { useSnippetContent } from "../lib";
 import { InvisibleSnippetTextArea } from "./InvisibleCodeBlockTextArea";
-import { useEffect, useRef, useState } from "react";
 
 export const CodeBlock = () => {
   const { htmlContent, codeThemeBackgroundColor, codeLineNumbers, language } =
@@ -79,30 +78,14 @@ const SnippetDisplayLoading = () => (
 );
 
 const CodeBlockHeader: React.FC<{ language: string }> = ({ language }) => {
-  const [text, setText] = useState<string>("");
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (!inputRef.current) {
-      return;
-    }
-
-    inputRef.current.style.width = "auto";
-    inputRef.current.style.width = `${inputRef.current.scrollWidth}px`;
-  }, [text]);
-
   return (
-    <label className={styles.codeBlockHeader} htmlFor="codeBlockTitle">
-      <input
-        type="text"
-        placeholder="Enter the title"
-        id="codeBlockTitle"
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        ref={inputRef}
-      />
-      <span>{language}</span>
-    </label>
+    <header className={styles.codeBlockHeader}>
+      <CodeBlockIcons />
+      <label className={styles.codeBlockLabel} htmlFor="codeBlockTitle">
+        <input type="text" placeholder="Enter the title" id="codeBlockTitle" />
+        <span>{language}</span>
+      </label>
+    </header>
   );
 };
 
@@ -125,4 +108,12 @@ const CodeBlockContent: React.FC<CodeBlockContentProps> = ({
       />
     </div>
   </section>
+);
+
+const CodeBlockIcons = () => (
+  <div className={styles.codeBlockIconWrapper}>
+    <span className={styles.codeBlockHeaderIcon} />
+    <span className={styles.codeBlockHeaderIcon} />
+    <span className={styles.codeBlockHeaderIcon} />
+  </div>
 );

--- a/app/src/features/snippet/ui/CodeBlock.tsx
+++ b/app/src/features/snippet/ui/CodeBlock.tsx
@@ -5,7 +5,7 @@ import { useSnippetContent } from "../lib";
 import { InvisibleSnippetTextArea } from "./InvisibleCodeBlockTextArea";
 
 export const CodeBlock = () => {
-  const { htmlContent, codeThemeBackgroundColor, codeLineNumbers } =
+  const { htmlContent, codeThemeBackgroundColor, codeLineNumbers, language } =
     useSnippetContent();
 
   if (!htmlContent) {
@@ -19,19 +19,19 @@ export const CodeBlock = () => {
         backgroundColor: codeThemeBackgroundColor,
       }}
     >
-      <div
+      <section
         id="codeBlock"
         className={styles.codeBlock}
         style={{
           backgroundColor: codeThemeBackgroundColor,
         }}
       >
-        <LineNumbers codeLineNumbers={codeLineNumbers} />
-        <div className={styles.codeContentArea}>
-          <InvisibleSnippetTextArea />
-          <RehypePrettyCodeBlock htmlContent={htmlContent} />
-        </div>
-      </div>
+        <CodeBlockHeader language={language} />
+        <CodeBlockContent
+          htmlContent={htmlContent}
+          codeLineNumbers={codeLineNumbers}
+        />
+      </section>
     </section>
   );
 };
@@ -46,15 +46,6 @@ const LineNumbers: React.FC<{ codeLineNumbers: number[] }> = ({
       </div>
     ))}
   </div>
-);
-
-const RehypePrettyCodeBlock: React.FC<{ htmlContent: string }> = ({
-  htmlContent,
-}) => (
-  <div
-    className={styles.snippetOutput}
-    dangerouslySetInnerHTML={{ __html: htmlContent }}
-  />
 );
 
 const SnippetDisplayLoading = () => (
@@ -82,6 +73,36 @@ const SnippetDisplayLoading = () => (
           </clipPath>
         </defs>
       </svg>
+    </div>
+  </section>
+);
+
+const CodeBlockHeader: React.FC<{ language: string }> = ({ language }) => {
+  return (
+    <header className={styles.codeBlockHeader}>
+      <input type="text" placeholder="Enter the title" id="codeBlockTitle" />
+      <span>{language}</span>
+    </header>
+  );
+};
+
+interface CodeBlockContentProps {
+  htmlContent: string;
+  codeLineNumbers: number[];
+}
+
+const CodeBlockContent: React.FC<CodeBlockContentProps> = ({
+  htmlContent,
+  codeLineNumbers,
+}) => (
+  <section className={styles.codeBlockContent}>
+    <LineNumbers codeLineNumbers={codeLineNumbers} />
+    <div className={styles.codeContentArea}>
+      <InvisibleSnippetTextArea />
+      <div
+        className={styles.snippetOutput}
+        dangerouslySetInnerHTML={{ __html: htmlContent }}
+      />
     </div>
   </section>
 );

--- a/app/src/features/snippet/ui/CodeBlock.tsx
+++ b/app/src/features/snippet/ui/CodeBlock.tsx
@@ -3,6 +3,7 @@
 import styles from "./styles.module.css";
 import { useSnippetContent } from "../lib";
 import { InvisibleSnippetTextArea } from "./InvisibleCodeBlockTextArea";
+import { useEffect, useRef, useState } from "react";
 
 export const CodeBlock = () => {
   const { htmlContent, codeThemeBackgroundColor, codeLineNumbers, language } =
@@ -78,11 +79,30 @@ const SnippetDisplayLoading = () => (
 );
 
 const CodeBlockHeader: React.FC<{ language: string }> = ({ language }) => {
+  const [text, setText] = useState<string>("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    inputRef.current.style.width = "auto";
+    inputRef.current.style.width = `${inputRef.current.scrollWidth}px`;
+  }, [text]);
+
   return (
-    <header className={styles.codeBlockHeader}>
-      <input type="text" placeholder="Enter the title" id="codeBlockTitle" />
+    <label className={styles.codeBlockHeader} htmlFor="codeBlockTitle">
+      <input
+        type="text"
+        placeholder="Enter the title"
+        id="codeBlockTitle"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        ref={inputRef}
+      />
       <span>{language}</span>
-    </header>
+    </label>
   );
 };
 

--- a/app/src/features/snippet/ui/DownloadSnippetButton.tsx
+++ b/app/src/features/snippet/ui/DownloadSnippetButton.tsx
@@ -11,6 +11,16 @@ export const DownloadSnippetButton = () => {
     $codeBlock.style.width = "fit-content";
     $codeBlock.style.overflow = "visible";
 
+    const $codeBlockTitle = document.querySelector(
+      "#codeBlockTitle"
+    ) as HTMLInputElement;
+
+    /* 타이틀이 존재하지 않는다면 placeHolder가 나타나지 않도록 visibility 조절 */
+
+    if ($codeBlockTitle.value.length < 1) {
+      $codeBlockTitle.style.visibility = "hidden";
+    }
+
     const canvas = await toCanvas($codeBlock, {
       pixelRatio: 5,
     });
@@ -26,6 +36,10 @@ export const DownloadSnippetButton = () => {
     /* 스크롤바 복원  */
     $codeBlock.style.width = originalWidth;
     $codeBlock.style.overflowX = originalOverflowX;
+
+    if ($codeBlockTitle.value.length < 1) {
+      $codeBlockTitle.style.visibility = "visible";
+    }
   };
 
   return (

--- a/app/src/features/snippet/ui/styles.module.css
+++ b/app/src/features/snippet/ui/styles.module.css
@@ -56,15 +56,14 @@
 }
 
 .codeBlockHeader > input {
-  flex: 1;
   background-color: transparent;
   font-style: inherit;
+  max-width: 80%;
 }
 
 .snippetOutput {
   white-space: pre-wrap;
   word-wrap: break-word;
-  width: 100%;
 }
 
 .snippetOutput > figure code {

--- a/app/src/features/snippet/ui/styles.module.css
+++ b/app/src/features/snippet/ui/styles.module.css
@@ -45,20 +45,52 @@
   font-variant-ligatures: none;
 }
 
-/* CodeBlockHeader */
+/* codeBlockHeader */
+
 .codeBlockHeader {
+  display: flex;
+  width: 100%;
+  gap: 0.5rem;
+  padding: 0.3rem 0.5rem 0.5rem 1rem;
+}
+
+.codeBlockLabel {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0 0.5rem 0.5rem 2rem;
   color: gray;
   font-style: italic;
+  flex-grow: 1;
 }
 
-.codeBlockHeader > input {
+.codeBlockLabel input {
   background-color: transparent;
-  font-style: inherit;
-  max-width: 80%;
+  width: 80%;
+  padding-right: 1rem;
+}
+
+.codeBlockIconWrapper {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.codeBlockHeaderIcon {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+}
+
+.codeBlockHeaderIcon:nth-child(1) {
+  background-color: #ff605c;
+}
+
+.codeBlockHeaderIcon:nth-child(2) {
+  background-color: #ffbd44;
+}
+
+.codeBlockHeaderIcon:nth-child(3) {
+  background-color: #00ca56;
 }
 
 .snippetOutput {

--- a/app/src/features/snippet/ui/styles.module.css
+++ b/app/src/features/snippet/ui/styles.module.css
@@ -59,7 +59,6 @@
   justify-content: space-between;
   gap: 1rem;
   color: gray;
-  font-style: italic;
   flex-grow: 1;
 }
 

--- a/app/src/features/snippet/ui/styles.module.css
+++ b/app/src/features/snippet/ui/styles.module.css
@@ -33,13 +33,32 @@
 }
 
 .codeBlock {
-  display: flex;
   border-radius: 12px;
-  padding: 1rem 1rem 1rem 0rem;
+  padding: 0.5rem 1rem 1rem 0rem;
+  overflow: auto;
+}
+
+.codeBlockContent {
+  display: flex;
   font-family: Jet-Brains, body-font, Menlo, SFMono-Regular, Monaco, Consolas,
     "Liberation Mono", "Courier New", monospace;
   font-variant-ligatures: none;
-  overflow: auto;
+}
+
+/* CodeBlockHeader */
+.codeBlockHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0 0.5rem 0.5rem 2rem;
+  color: gray;
+  font-style: italic;
+}
+
+.codeBlockHeader > input {
+  flex: 1;
+  background-color: transparent;
+  font-style: inherit;
 }
 
 .snippetOutput {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ec2b87bb-7681-4967-a014-7729f5f8c219)


다음과 같이 수정하고 전체 header 라인 영역에 label 영역을 감싸줌으로서 input 버튼을 손쉽게 클릭 할 수 있도록 함 

![image](https://github.com/user-attachments/assets/2d80cd2e-0c8e-4599-8531-686a561b59d4)

만일 제목이 비어있는 상황이라면 `visibility` 를  `hidden` 으로 변경하도록 한다. 

![image](https://github.com/user-attachments/assets/508eea68-d0ac-4962-a12b-c04d15ab4a97)
